### PR TITLE
database: Do not call close() on finalize

### DIFF
--- a/xapian-glib/xapian-database.cc
+++ b/xapian-glib/xapian-database.cc
@@ -200,11 +200,7 @@ xapian_database_finalize (GObject *self)
 {
   XapianDatabasePrivate *priv = XAPIAN_DATABASE_GET_PRIVATE (self);
 
-  if (priv->mDB)
-    {
-      priv->mDB->close ();
-      delete priv->mDB;
-    }
+  delete priv->mDB;
 
   g_free (priv->path);
 


### PR DESCRIPTION
The internals of Xapian::Database are refcounted, so if something
collects the database instance it'll be closed only if it's the last
reference. We don't need to explicitly do this on the bindings side,
and we can safely leave it to Xapian to handle the closing of the
database.

[endlessm/eos-sdk#1408]
