### PR TITLE
Add missing include file

### DIFF
--- a/xapian-glib/xapian-database.cc
+++ b/xapian-glib/xapian-database.cc
@@ -28,6 +28,7 @@
 
 #include "config.h"
 
+#include <errno.h>
 #include <sys/types.h>
 #include <fcntl.h>
 


### PR DESCRIPTION
This somehow already got included when I built it locally, but not on a
fresh install.

https://phabricator.endlessm.com/T13324