### PR TITLE
Correct "Since x.y.z" to "Since: x.y.z"

### DIFF
--- a/xapian-glib/xapian-query-parser.cc
+++ b/xapian-glib/xapian-query-parser.cc
@@ -202,7 +202,7 @@ xapian_query_parser_class_init (XapianQueryParserClass *klass)
    * XapianQueryParser:stopper:
    *
    * The #XapianStopper to be used for dropping stop words
-   * Since 1.2
+   * Since: 1.2
    */
   obj_props[PROP_STOPPER] =
     g_param_spec_object ("stopper",
@@ -356,7 +356,7 @@ xapian_query_parser_set_database (XapianQueryParser *parser,
  * @stopper: a #XapianStopper
  *
  * Sets the @stopper used by @parser stop word elimination.
- * Since 1.2
+ * Since: 1.2
  */
 void
 xapian_query_parser_set_stopper (XapianQueryParser *parser,

--- a/xapian-glib/xapian-simple-stopper.cc
+++ b/xapian-glib/xapian-simple-stopper.cc
@@ -59,7 +59,7 @@ xapian_simple_stopper_init (XapianSimpleStopper *self)
  *
  * Adds a single stop word.
  *
- * Since 1.2
+ * Since: 1.2
  */
 void
 xapian_simple_stopper_add (XapianSimpleStopper *stopper,
@@ -79,7 +79,7 @@ xapian_simple_stopper_add (XapianSimpleStopper *stopper,
  *
  * Returns: (transfer full): the newly created #XapianSimpleStopper instance
  *
- * Since 1.2
+ * Since: 1.2
  */
 XapianSimpleStopper *
 xapian_simple_stopper_new ()

--- a/xapian-glib/xapian-stopper.cc
+++ b/xapian-glib/xapian-stopper.cc
@@ -119,7 +119,7 @@ xapian_stopper_set_internal (XapianStopper   *self,
  * Returns a string describing this object.
  *
  * Returns: (transfer full): description of the stopper
- * Since 1.2
+ * Since: 1.2
  */
 char *
 xapian_stopper_get_description (XapianStopper *self)


### PR DESCRIPTION
Documentation tools won't pick this up without the colon.