### PR TITLE
Fix deprecation warning

### DIFF
--- a/xapian-glib/xapian-posting-source-private.h
+++ b/xapian-glib/xapian-posting-source-private.h
@@ -25,6 +25,6 @@ Xapian::PostingSource *      xapian_posting_source_get_internal    (XapianPostin
 
 void                         xapian_posting_source_set_internal    (XapianPostingSource   *self, Xapian::PostingSource *aPostingSource);
 
-void                         xapian_posting_source_set_max_weight  (XapianPostingSource   *self, Xapian::weight max_weight);
+void                         xapian_posting_source_set_max_weight  (XapianPostingSource   *self, double max_weight);
 
 #endif /* __XAPIAN_GLIB_POSTING_SOURCE_PRIVATE_H__ */

--- a/xapian-glib/xapian-posting-source.cc
+++ b/xapian-glib/xapian-posting-source.cc
@@ -69,7 +69,7 @@ class GenericPostingSource : public Xapian::PostingSource {
         return -1;
     }
 
-    virtual void next(Xapian::weight min_wt) {
+    virtual void next(double min_wt) {
     }
 
     virtual bool at_end() const {


### PR DESCRIPTION
Recent Xapian deprecates Xapian::weight in favour of simply using
double, which also works fine with older versions.