### PR TITLE
Changes to make Xapian-GLib build against Xapian 1.4

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -71,17 +71,17 @@ AC_CANONICAL_HOST
 AS_IF([test "x$GCC" = "xyes"],
       [
         # make symbols link locally
-        LDFLAGS="$LDFLAGS -Bsymbolic-functions"
+        BUILD_LDFLAGS="$BUILD_LDFLAGS -Bsymbolic-functions"
 
         # assorted compiler errors
-        CXXFLAGS="$CXXFLAGS -Wall -ansi"
-        CXXFLAGS="$CXXFLAGS -Werror=cast-align"
-        CXXFLAGS="$CXXFLAGS -Werror=shadow"
-        CXXFLAGS="$CXXFLAGS -Werror=format"
-        CXXFLAGS="$CXXFLAGS -Werror=format-security"
-        CXXFLAGS="$CXXFLAGS -Werror=format-nonliteral"
-        CXXFLAGS="$CXXFLAGS -Werror=init-self"
-        CXXFLAGS="$CXXFLAGS -Werror=empty-body"
+        BUILD_CXXFLAGS="$BUILD_CXXFLAGS -Wall -ansi"
+        BUILD_CXXFLAGS="$BUILD_CXXFLAGS -Werror=cast-align"
+        BUILD_CXXFLAGS="$BUILD_CXXFLAGS -Werror=shadow"
+        BUILD_CXXFLAGS="$BUILD_CXXFLAGS -Werror=format"
+        BUILD_CXXFLAGS="$BUILD_CXXFLAGS -Werror=format-security"
+        BUILD_CXXFLAGS="$BUILD_CXXFLAGS -Werror=format-nonliteral"
+        BUILD_CXXFLAGS="$BUILD_CXXFLAGS -Werror=init-self"
+        BUILD_CXXFLAGS="$BUILD_CXXFLAGS -Werror=empty-body"
 
         AS_CASE(["$host"],
                 [*-*-mingw*],
@@ -90,8 +90,8 @@ AS_IF([test "x$GCC" = "xyes"],
                   AC_DEFINE([_XAPIAN_GLIB_EXTERN],
                             [__attribute__((visibility("default"))) __declspec(dllexport) extern],
                             [defines how to decorate public symbols while building])
-                  CXXFLAGS="$CXXFLAGS -fvisibility=hidden"
-                  LDFLAGS="$LDFLAGS -no-undefined"
+                  BUILD_CXXFLAGS="$BUILD_CXXFLAGS -fvisibility=hidden"
+                  BUILD_LDFLAGS="$BUILD_LDFLAGS -no-undefined"
                 ],
 
                 [
@@ -99,15 +99,15 @@ AS_IF([test "x$GCC" = "xyes"],
                   AC_DEFINE([_XAPIAN_GLIB_EXTERN],
                             [__attribute__((visibility("default"))) extern],
                             [defines how to decorate public symbols while building])
-                  CXXFLAGS="$CXXFLAGS -fvisibility-inlines-hidden"
-                  CXXFLAGS="$CXXFLAGS -fvisibility=hidden"
+                  BUILD_CXXFLAGS="$BUILD_CXXFLAGS -fvisibility-inlines-hidden"
+                  BUILD_CXXFLAGS="$BUILD_CXXFLAGS -fvisibility=hidden"
                 ])
 
         AS_CASE(["$host"],
                 [arm-*-*],
                 [
                   # request byte alignment on ARM
-                  CXXFLAGS="$CXXFLAGS -mstructure-size-boundary=8"
+                  BUILD_CXXFLAGS="$BUILD_CXXFLAGS -mstructure-size-boundary=8"
                 ])
       ]
 )
@@ -122,13 +122,13 @@ AC_ARG_WITH([xapian-config], [AS_HELP_STRING([--with-xapian-config], [The xapian
 
 AS_IF([test "x$xapian_config" = xauto], [
   PKG_CHECK_MODULES(XAPIAN, [xapian-core])
-  CXXFLAGS="$CXXFLAGS $XAPIAN_CFLAGS"
+  BUILD_CXXFLAGS="$BUILD_CXXFLAGS $XAPIAN_CFLAGS"
 ], [
   AC_CHECK_PROG([XAPIAN_CONFIG], $xapian_config, $xapian_config, no)
   AS_IF([test "x$XAPIAN_CONFIG" = xno], [
     AC_MSG_ERROR("*** No Xapian headers found. You need to install xapian-core ***")
   ])
-  CXXFLAGS="$CXXFLAGS `$XAPIAN_CONFIG --cxxflags`"
+  BUILD_CXXFLAGS="$BUILD_CXXFLAGS `$XAPIAN_CONFIG --cxxflags`"
   XAPIAN_LIBS="`$XAPIAN_CONFIG --ltlibs`"
 ])
 
@@ -227,11 +227,11 @@ AS_IF([test "x$use_gcov" = "xyes"],
 
         dnl Remove all optimization flags from CFLAGS
         m4_changequote({,})
-        CXXFLAGS=`echo "$CXXFLAGS" | $SED -e 's/-O[0-9]*//g'`
+        BUILD_CXXFLAGS=`echo "$BUILD_CXXFLAGS" | $SED -e 's/-O[0-9]*//g'`
         m4_changequote([,])
 
         dnl Define the special gcc flags
-        CXXFLAGS="$CXXFLAGS -O0 -fprofile-arcs -ftest-coverage"
+        BUILD_CXXFLAGS="$BUILD_CXXFLAGS -O0 -fprofile-arcs -ftest-coverage"
         XAPIAN_GLIB_LIBS="$XAPIAN_GLIB_LIBS -lgcov"
       ])
 
@@ -256,6 +256,8 @@ AC_SUBST(XAPIAN_GLIB_CFLAGS)
 AC_SUBST(XAPIAN_GLIB_DEBUG_CFLAGS)
 AC_SUBST(XAPIAN_GLIB_LIBS)
 AC_SUBST(XAPIAN_LIBS)
+AC_SUBST(BUILD_CXXFLAGS)
+AC_SUBST(BUILD_LDFLAGS)
 
 AC_CONFIG_FILES([
         Makefile
@@ -283,6 +285,6 @@ Build configuration:
   • Prefix: ${prefix}
   • Debug level: ${enable_debug}
   • Xapian configuration: ${xapian_config}
-  • Compiler flags: ${CXXFLAGS}
+  • Compiler flags: ${BUILD_CXXFLAGS} ${BUILD_LDFLAGS}
   • Introspection: ${have_introspection}
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -282,6 +282,7 @@ Build configuration:
 
   • Prefix: ${prefix}
   • Debug level: ${enable_debug}
+  • Xapian configuration: ${xapian_config}
   • Compiler flags: ${CXXFLAGS}
   • Introspection: ${have_introspection}
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -36,6 +36,7 @@ AC_CONFIG_SRCDIR([xapian-glib/xapian-glib.h])
 
 AM_INIT_AUTOMAKE([1.11.2 no-define foreign -Wno-portability dist-xz no-dist-gzip tar-ustar])
 AM_SILENT_RULES([yes])
+AM_MAINTAINER_MODE([enable])
 
 LT_PREREQ([2.2.6])
 LT_INIT([disable-static])
@@ -115,14 +116,21 @@ AM_CONDITIONAL(HAVE_GCC, test "x$GCC" = "xyes")
 
 dnl === Dependencies ==========================================================
 
-AC_CHECK_PROG([XAPIAN_CONFIG], [xapian-config-1.3], [xapian-config-1.3])
-AS_IF([test "$XAPIAN_CONFIG"],
-      [ found_xapian=yes ],
-      [ AC_MSG_ERROR(["*** No Xapian headers found; you need to install xapian-config ***"]) ])
+AC_ARG_WITH([xapian-config], [AS_HELP_STRING([--with-xapian-config], [The xapian-config binary])],
+            [xapian_config=$withval],
+            [xapian_config=auto])
 
-CXXFLAGS="$CXXFLAGS `$XAPIAN_CONFIG --cxxflags`"
-
-XAPIAN_LIBS="`$XAPIAN_CONFIG --ltlibs`"
+AS_IF([test "x$xapian_config" = xauto], [
+  PKG_CHECK_MODULES(XAPIAN, [xapian-core])
+  CXXFLAGS="$CXXFLAGS $XAPIAN_CFLAGS"
+], [
+  AC_CHECK_PROG([XAPIAN_CONFIG], $xapian_config, $xapian_config, no)
+  AS_IF([test "x$XAPIAN_CONFIG" = xno], [
+    AC_MSG_ERROR("*** No Xapian headers found. You need to install xapian-core ***")
+  ])
+  CXXFLAGS="$CXXFLAGS `$XAPIAN_CONFIG --cxxflags`"
+  XAPIAN_LIBS="`$XAPIAN_CONFIG --ltlibs`"
+])
 
 PKG_CHECK_MODULES(XAPIAN_GLIB, [gobject-2.0 >= glib_req_version gio-2.0])
 

--- a/configure.ac
+++ b/configure.ac
@@ -116,13 +116,14 @@ AM_CONDITIONAL(HAVE_GCC, test "x$GCC" = "xyes")
 
 dnl === Dependencies ==========================================================
 
-AC_ARG_WITH([xapian-config], [AS_HELP_STRING([--with-xapian-config], [The xapian-config binary])],
+AC_ARG_WITH([xapian-config], [AS_HELP_STRING([--with-xapian-config], [The xapian-config binary or 'pkgconfig'])],
             [xapian_config=$withval],
-            [xapian_config=auto])
+            [xapian_config=pkgconfig])
 
-AS_IF([test "x$xapian_config" = xauto], [
+AS_IF([test "x$xapian_config" = xpkgconfig], [
   PKG_CHECK_MODULES(XAPIAN, [xapian-core])
   BUILD_CXXFLAGS="$BUILD_CXXFLAGS $XAPIAN_CFLAGS"
+  XAPIAN_VERSION="`$PKG_CONFIG --modversion xapian-core`"
 ], [
   AC_CHECK_PROG([XAPIAN_CONFIG], $xapian_config, $xapian_config, no)
   AS_IF([test "x$XAPIAN_CONFIG" = xno], [
@@ -130,6 +131,7 @@ AS_IF([test "x$xapian_config" = xauto], [
   ])
   BUILD_CXXFLAGS="$BUILD_CXXFLAGS `$XAPIAN_CONFIG --cxxflags`"
   XAPIAN_LIBS="`$XAPIAN_CONFIG --ltlibs`"
+  XAPIAN_VERSION="`$XAPIAN_CONFIG --version`"
 ])
 
 PKG_CHECK_MODULES(XAPIAN_GLIB, [gobject-2.0 >= glib_req_version gio-2.0])
@@ -284,7 +286,7 @@ Build configuration:
 
   • Prefix: ${prefix}
   • Debug level: ${enable_debug}
-  • Xapian configuration: ${xapian_config}
+  • Xapian version: ${XAPIAN_VERSION} (${xapian_config})
   • Compiler flags: ${BUILD_CXXFLAGS} ${BUILD_LDFLAGS}
   • Introspection: ${have_introspection}
 ])

--- a/xapian-glib/Makefile.am
+++ b/xapian-glib/Makefile.am
@@ -3,6 +3,7 @@
 NULL =
 
 AM_CPPFLAGS =
+AM_CXXFLAGS =
 AM_CFLAGS =
 BUILT_SOURCES =
 
@@ -95,8 +96,9 @@ libxapian_glib_1_0_la_CPPFLAGS = \
 	$(XAPIAN_GLIB_CFLAGS) \
 	$(NULL)
 
+libxapian_glib_1_0_la_CXXFLAGS = $(BUILD_CXXFLAGS)
 libxapian_glib_1_0_la_LIBADD = $(XAPIAN_GLIB_LIBS) $(XAPIAN_LIBS)
-libxapian_glib_1_0_la_LDFLAGS = $(XAPIAN_GLIB_LDFLAGS) -export-dynamic
+libxapian_glib_1_0_la_LDFLAGS = $(XAPIAN_GLIB_LDFLAGS) $(BUILD_LDFLAGS) -export-dynamic
 libxapian_glib_1_0_la_SOURCES = $(source_h_public) $(source_h_private) $(source_c_public) $(source_c_private)
 
 # Use a C linker for GCC, not C++; Don't link to libstdc++

--- a/xapian-glib/xapian-query-parser.cc
+++ b/xapian-glib/xapian-query-parser.cc
@@ -319,7 +319,6 @@ xapian_query_parser_set_stemming_strategy (XapianQueryParser  *parser,
 
   Xapian::QueryParser::stem_strategy stem_strategy;
 
-#ifdef XAPIAN_GLIB_ENABLE_DEBUG
   switch (priv->stemming_strategy)
     {
     case XAPIAN_STEM_STRATEGY_STEM_NONE:
@@ -341,9 +340,6 @@ xapian_query_parser_set_stemming_strategy (XapianQueryParser  *parser,
     default:
       g_assert_not_reached ();
     }
-#else
-  stem_strategy = static_cast<Xapian::QueryParser::stem_strategy> (priv->stemming_strategy);
-#endif
 
   priv->mQueryParser->set_stemming_strategy (stem_strategy);
 
@@ -564,8 +560,6 @@ xapian_query_parser_parse_query_full (XapianQueryParser        *parser,
     {
       unsigned int real_flags = 0;
 
-#ifdef XAPIAN_GLIB_ENABLE_DEBUG
-      /* overzealous flag conversion */
       if (flags & XAPIAN_QUERY_PARSER_FEATURE_BOOLEAN)
         real_flags |= Xapian::QueryParser::FLAG_BOOLEAN;
       if (flags & XAPIAN_QUERY_PARSER_FEATURE_PHRASE)
@@ -588,12 +582,6 @@ xapian_query_parser_parse_query_full (XapianQueryParser        *parser,
         real_flags |= Xapian::QueryParser::FLAG_AUTO_SYNONYMS;
       if (flags & XAPIAN_QUERY_PARSER_FEATURE_AUTO_MULTIWORD_SYNONYMS)
         real_flags |= Xapian::QueryParser::FLAG_AUTO_MULTIWORD_SYNONYMS;
-#else
-      /* the XapianQueryParserFeature enumeration values match
-       * the Xapian::QueryParser::feature_flag enumeration
-       */
-      real_flags = flags;
-#endif
 
       Xapian::Query query = priv->mQueryParser->parse_query (std::string (query_string),
                                                              real_flags,

--- a/xapian-glib/xapian-query.cc
+++ b/xapian-glib/xapian-query.cc
@@ -59,7 +59,6 @@ xapian_query_op_internal (XapianQueryOp op)
 {
   Xapian::Query::op query_op = Xapian::Query::OP_AND;
 
-#ifdef XAPIAN_GLIB_ENABLE_DEBUG
   switch (op)
     {
     case XAPIAN_QUERY_OP_AND:
@@ -121,10 +120,6 @@ xapian_query_op_internal (XapianQueryOp op)
     default:
       g_assert_not_reached ();
     }
-#else
-  /* we keep XapianQueryOP and Xapian::Query::op in sync */
-  query_op = (Xapian::Query::op) op;
-#endif /* XAPIAN_GLIB_ENABLE_DEBUG */
 
   return query_op;
 }

--- a/xapian-glib/xapian-term-generator.cc
+++ b/xapian-glib/xapian-term-generator.cc
@@ -337,7 +337,6 @@ xapian_term_generator_set_stemming_strategy (XapianTermGenerator *generator,
 
   Xapian::TermGenerator::stem_strategy stem_strategy;
 
-#ifdef XAPIAN_GLIB_ENABLE_DEBUG
   switch (priv->stemming_strategy)
     {
     case XAPIAN_STEM_STRATEGY_STEM_NONE:
@@ -359,9 +358,6 @@ xapian_term_generator_set_stemming_strategy (XapianTermGenerator *generator,
     default:
       g_assert_not_reached ();
     }
-#else
-  stem_strategy = (Xapian::TermGenerator::stem_strategy) priv->stemming_strategy;
-#endif
 
   priv->mGenerator->set_stemming_strategy (stem_strategy);
 

--- a/xapian-glib/xapian-writable-database.cc
+++ b/xapian-glib/xapian-writable-database.cc
@@ -93,7 +93,23 @@ xapian_writable_database_init_internal (GInitable    *initable,
   try
     {
       std::string file (path);
-      db = new Xapian::WritableDatabase (file, (int) priv->action | xapian_database_get_flags (database));
+
+      /* Xapian >= 1.3 changed the values of these flags; in order to work
+       * with Xapian 1.2 we need to do a manual translation of every value
+       * into the equivalent Xapian constant
+       */
+      int flags = xapian_database_get_flags (database);
+
+      if ((priv->action & XAPIAN_DATABASE_ACTION_CREATE_OR_OPEN) != 0)
+        flags |= Xapian::DB_CREATE_OR_OPEN;
+      if ((priv->action & XAPIAN_DATABASE_ACTION_CREATE_OR_OVERWRITE) != 0)
+        flags |= Xapian::DB_CREATE_OR_OVERWRITE;
+      if ((priv->action & XAPIAN_DATABASE_ACTION_CREATE) != 0)
+        flags |= Xapian::DB_CREATE;
+      if ((priv->action & XAPIAN_DATABASE_ACTION_OPEN) != 0)
+        flags |= Xapian::DB_OPEN;
+
+      db = new Xapian::WritableDatabase (file, flags);
 
       xapian_database_set_internal (database, db);
       xapian_database_set_is_writable (database, TRUE);


### PR DESCRIPTION
The current stable version of Xapian is 1.4, but we're still building against Xapian 1.3 on Endless.

We want to allow people to use Xapian-GLib with newer versions of Xapian, but we also want to keep supporting the version of Xapian on Endless OS.