### PR TITLE
rules: Configure against xapian-config-1.3

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -12,5 +12,8 @@
 %:
 	dh $@ --with gir
 
+override_dh_auto_configure:
+	dh_auto_configure -- --with-xapian-config=xapian-config-1.3
+
 override_dh_strip:
 	dh_strip --dbg-package=libxapian-glib-1.0-dbg


### PR DESCRIPTION
This is what we have in Endless.