### PR TITLE
Always translate the XapianDatabase flags

### DIFF
--- a/xapian-glib/xapian-database-private.h
+++ b/xapian-glib/xapian-database-private.h
@@ -28,6 +28,6 @@ void			xapian_database_set_is_writable	(XapianDatabase   *self,
 							 gboolean          is_writable);
 gboolean                xapian_database_get_is_writable (XapianDatabase   *self);
 const char *            xapian_database_get_path        (XapianDatabase   *self);
-XapianDatabaseFlags     xapian_database_get_flags       (XapianDatabase   *self);
+int                     xapian_database_get_flags       (XapianDatabase   *self);
 
 #endif /* __XAPIAN_GLIB_DATABASE_PRIVATE_H__ */

--- a/xapian-glib/xapian-database.cc
+++ b/xapian-glib/xapian-database.cc
@@ -172,22 +172,7 @@ open_database (XapianDatabase *self)
 
   if (priv->path != NULL && priv->path[0] != '\0')
     {
-      int db_flags = 0;
-
-      if (priv->flags & XAPIAN_DB_NO_SYNC)
-        db_flags |= Xapian::DB_NO_SYNC;
-      if (priv->flags & XAPIAN_DB_FULL_SYNC)
-        db_flags |= Xapian::DB_FULL_SYNC;
-      if (priv->flags & XAPIAN_DB_DANGEROUS)
-        db_flags |= Xapian::DB_DANGEROUS;
-      if (priv->flags & XAPIAN_DB_RETRY_LOCK)
-        db_flags |= Xapian::DB_RETRY_LOCK;
-      if (priv->flags & XAPIAN_DB_BACKEND_GLASS)
-        db_flags |= Xapian::DB_BACKEND_GLASS;
-      if (priv->flags & XAPIAN_DB_BACKEND_CHERT)
-        db_flags |= Xapian::DB_BACKEND_CHERT;
-      if (priv->flags & XAPIAN_DB_BACKEND_STUB)
-        db_flags |= Xapian::DB_BACKEND_STUB;
+      int db_flags = xapian_database_get_flags (self);
 
       /* If we're given an offset, open the database at that location */
       if (priv->offset != 0)
@@ -700,9 +685,26 @@ xapian_database_compact_to_fd (XapianDatabase             *self,
 #endif
 }
 
-XapianDatabaseFlags
+int
 xapian_database_get_flags (XapianDatabase *self)
 {
   XapianDatabasePrivate *priv = XAPIAN_DATABASE_GET_PRIVATE (self);
-  return priv->flags;
+  int db_flags = 0;
+
+  if (priv->flags & XAPIAN_DB_NO_SYNC)
+    db_flags |= Xapian::DB_NO_SYNC;
+  if (priv->flags & XAPIAN_DB_FULL_SYNC)
+    db_flags |= Xapian::DB_FULL_SYNC;
+  if (priv->flags & XAPIAN_DB_DANGEROUS)
+    db_flags |= Xapian::DB_DANGEROUS;
+  if (priv->flags & XAPIAN_DB_RETRY_LOCK)
+    db_flags |= Xapian::DB_RETRY_LOCK;
+  if (priv->flags & XAPIAN_DB_BACKEND_GLASS)
+    db_flags |= Xapian::DB_BACKEND_GLASS;
+  if (priv->flags & XAPIAN_DB_BACKEND_CHERT)
+    db_flags |= Xapian::DB_BACKEND_CHERT;
+  if (priv->flags & XAPIAN_DB_BACKEND_STUB)
+    db_flags |= Xapian::DB_BACKEND_STUB;
+
+  return db_flags; 
 }

--- a/xapian-glib/xapian-writable-database.cc
+++ b/xapian-glib/xapian-writable-database.cc
@@ -98,18 +98,18 @@ xapian_writable_database_init_internal (GInitable    *initable,
        * with Xapian 1.2 we need to do a manual translation of every value
        * into the equivalent Xapian constant
        */
-      int flags = xapian_database_get_flags (database);
+      int db_flags = xapian_database_get_flags (database);
 
       if ((priv->action & XAPIAN_DATABASE_ACTION_CREATE_OR_OPEN) != 0)
-        flags |= Xapian::DB_CREATE_OR_OPEN;
+        db_flags |= Xapian::DB_CREATE_OR_OPEN;
       if ((priv->action & XAPIAN_DATABASE_ACTION_CREATE_OR_OVERWRITE) != 0)
-        flags |= Xapian::DB_CREATE_OR_OVERWRITE;
+        db_flags |= Xapian::DB_CREATE_OR_OVERWRITE;
       if ((priv->action & XAPIAN_DATABASE_ACTION_CREATE) != 0)
-        flags |= Xapian::DB_CREATE;
+        db_flags |= Xapian::DB_CREATE;
       if ((priv->action & XAPIAN_DATABASE_ACTION_OPEN) != 0)
-        flags |= Xapian::DB_OPEN;
+        db_flags |= Xapian::DB_OPEN;
 
-      db = new Xapian::WritableDatabase (file, flags);
+      db = new Xapian::WritableDatabase (file, db_flags);
 
       xapian_database_set_internal (database, db);
       xapian_database_set_is_writable (database, TRUE);


### PR DESCRIPTION
When creating a new WritableDatabase we take the flags from the Database
base class and we OR them with the ones from the child class. Since we
store the flags as coming from the C API, we need to translate them to
their equivalent C++ values, otherwise they may not match what Xapian
expects.

https://phabricator.endlessm.com/T17251