### PR TITLE
Fix version check logic

### DIFF
--- a/xapian-glib/xapian-private.h
+++ b/xapian-glib/xapian-private.h
@@ -11,6 +11,6 @@
 
 /* This is an internal version check macro for the Xapian version */
 #define XAPIAN_CHECK_VERSION_INTERNAL(maj,min,rev) \
-   (_XAPIAN_CUR_VERSION > _XAPIAN_VERSION_ENCODE_INTERNAL(maj,min,rev))
+   (_XAPIAN_CUR_VERSION >= _XAPIAN_VERSION_ENCODE_INTERNAL(maj,min,rev))
 
 #endif


### PR DESCRIPTION
Old logic did not properly evaluate equality check for versions. The
change here makes sure that the same maj/min/rev version check can
be passed.

https://phabricator.endlessm.com/T17251

@ebassi: I think this is a fix for the SOMA side of things but would be good for you to take a look.