### PR TITLE
Fix sortable_serialise API wrapping

### DIFF
--- a/xapian-glib/tests/.gitignore
+++ b/xapian-glib/tests/.gitignore
@@ -1,5 +1,6 @@
 database
 document
 query-parser
+sortable-serialise
 stem
 writable-database

--- a/xapian-glib/tests/Makefile.am
+++ b/xapian-glib/tests/Makefile.am
@@ -12,4 +12,5 @@ test_programs = \
 	database \
 	document \
 	query-parser \
+	sortable-serialise \
 	stem

--- a/xapian-glib/tests/sortable-serialise.c
+++ b/xapian-glib/tests/sortable-serialise.c
@@ -1,0 +1,32 @@
+#include <glib.h>
+#include "xapian-glib.h"
+
+static void
+sortable_serialise_roundtrip (void)
+{
+  static const double values[] = {
+    -1234.0,
+    0.0,
+    0.125,
+    2049.0, /* Serialised form contains embedded zero byte. */
+  };
+  size_t i;
+
+  for (i = 0; i != G_N_ELEMENTS (values); ++i)
+    {
+      gsize len;
+      guchar *s = xapian_sortable_serialise (values[i], &len);
+      g_assert_cmpfloat (xapian_sortable_unserialise (s, len), ==, values[i]);
+      g_free (s);
+    }
+}
+
+int
+main (int argc, char *argv[])
+{
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add_func ("/sortable-serialise/roundtrip", sortable_serialise_roundtrip);
+
+  return g_test_run ();
+}

--- a/xapian-glib/tests/sortable-serialise.c
+++ b/xapian-glib/tests/sortable-serialise.c
@@ -22,7 +22,8 @@ sortable_serialise_roundtrip (void)
 }
 
 int
-main (int argc, char *argv[])
+main (int   argc,
+      char *argv[])
 {
   g_test_init (&argc, &argv, NULL);
 

--- a/xapian-glib/xapian-utils.cc
+++ b/xapian-glib/xapian-utils.cc
@@ -154,6 +154,8 @@ guchar *
 xapian_sortable_serialise (double  value,
                            gsize  *len)
 {
+  g_return_val_if_fail (len != NULL, NULL);
+
   const std::string &result = Xapian::sortable_serialise (value);
   gsize size = result.size ();
   guchar *buf = static_cast<guchar *> (g_malloc (size));
@@ -185,6 +187,8 @@ double
 xapian_sortable_unserialise (const guchar *value,
                              gsize         len)
 {
+  g_return_val_if_fail (value != NULL, 0.0);
+
   const char *p = reinterpret_cast<const char*> (value);
   return Xapian::sortable_unserialise (std::string (p, len));
 }

--- a/xapian-glib/xapian-utils.cc
+++ b/xapian-glib/xapian-utils.cc
@@ -151,7 +151,8 @@ xapian_revision (void)
  * Since: 1.4
  */
 guchar *
-xapian_sortable_serialise (double value, gsize *len)
+xapian_sortable_serialise (double  value,
+                           gsize  *len)
 {
   const std::string &result = Xapian::sortable_serialise (value);
   gsize size = result.size ();
@@ -181,7 +182,8 @@ xapian_sortable_serialise (double value, gsize *len)
  * Since: 1.4
  */
 double
-xapian_sortable_unserialise (const guchar *value, gsize len)
+xapian_sortable_unserialise (const guchar *value,
+                             gsize         len)
 {
   const char *p = reinterpret_cast<const char*> (value);
   return Xapian::sortable_unserialise (std::string (p, len));

--- a/xapian-glib/xapian-utils.h
+++ b/xapian-glib/xapian-utils.h
@@ -39,9 +39,9 @@ int             xapian_minor_version            (void);
 XAPIAN_GLIB_AVAILABLE_IN_1_0
 int             xapian_revision                 (void);
 XAPIAN_GLIB_AVAILABLE_IN_1_4
-char *          xapian_sortable_serialise       (double value);
+guchar *        xapian_sortable_serialise       (double value, gsize *len);
 XAPIAN_GLIB_AVAILABLE_IN_1_4
-double          xapian_sortable_unserialise     (const char *value);
+double          xapian_sortable_unserialise     (const guchar *value, gsize len);
 
 G_END_DECLS
 

--- a/xapian-glib/xapian-utils.h
+++ b/xapian-glib/xapian-utils.h
@@ -39,9 +39,11 @@ int             xapian_minor_version            (void);
 XAPIAN_GLIB_AVAILABLE_IN_1_0
 int             xapian_revision                 (void);
 XAPIAN_GLIB_AVAILABLE_IN_1_4
-guchar *        xapian_sortable_serialise       (double value, gsize *len);
+guchar *        xapian_sortable_serialise       (double  value,
+                                                 gsize  *len);
 XAPIAN_GLIB_AVAILABLE_IN_1_4
-double          xapian_sortable_unserialise     (const guchar *value, gsize len);
+double          xapian_sortable_unserialise     (const guchar *value,
+                                                 gsize         len);
 
 G_END_DECLS
 


### PR DESCRIPTION
The returned strings can contain zero bytes, so we need to return
and accept a length as well as the string data.

Fixes #54.