### PR TITLE
Simplify XapianMSetIterator implementation

### DIFF
--- a/xapian-glib/xapian-mset-iterator.cc
+++ b/xapian-glib/xapian-mset-iterator.cc
@@ -211,9 +211,6 @@ class IteratorData {
     }
 
     char * getDescription () {
-      if (!mCurrentInitialized)
-        return NULL;
-
       std::string desc = mCurrent.get_description ();
 
       return g_strdup (desc.c_str ());

--- a/xapian-glib/xapian-mset-iterator.cc
+++ b/xapian-glib/xapian-mset-iterator.cc
@@ -20,6 +20,8 @@
 #include "xapian-document-private.h"
 #include "xapian-error-private.h"
 
+#include <xapian/iterator.h>
+
 /**
  * SECTION:xapian-mset-iterator
  * @Title: XapianMSetIterator
@@ -55,20 +57,15 @@
 
 class IteratorData {
   public:
-    IteratorData (const IteratorData &aData) {
+    IteratorData (const IteratorData &aData)
+        : mCurrent (aData.mCurrent)
+    {
       if (aData.mMSet)
         mMSet = static_cast<XapianMSet *> (g_object_ref (aData.mMSet));
       else
         mMSet = NULL;
 
-      mBegin = new Xapian::MSetIterator (*aData.mBegin);
-      mEnd = new Xapian::MSetIterator (*aData.mEnd);
-
       mCurrentInitialized = aData.mCurrentInitialized;
-      if (mCurrentInitialized)
-        mCurrent = new Xapian::MSetIterator (*aData.mCurrent);
-      else
-        mCurrent = NULL;
 
       if (aData.mDocument)
         mDocument = static_cast<XapianDocument *> (g_object_ref (aData.mDocument));
@@ -76,24 +73,17 @@ class IteratorData {
         mDocument = NULL;
     }
 
-    IteratorData (XapianMSet *aMset) {
+    IteratorData (XapianMSet *aMset)
+        : mCurrent (xapian_mset_get_internal (aMset)->begin ())
+    {
       mMSet = static_cast<XapianMSet *> (g_object_ref (aMset));
 
-      Xapian::MSet *realMSet = xapian_mset_get_internal (aMset);
-
-      mBegin = new Xapian::MSetIterator (realMSet->begin ());
-      mEnd = new Xapian::MSetIterator (realMSet->end ());
-      mCurrent = NULL;
       mCurrentInitialized = false;
 
       mDocument = NULL;
     }
 
     ~IteratorData () {
-      delete mBegin;
-      delete mEnd;
-      delete mCurrent;
-
       if (mMSet)
         g_object_unref (mMSet);
 
@@ -105,71 +95,72 @@ class IteratorData {
       if (!mCurrentInitialized)
         return false;
 
-      return *mCurrent == *mBegin;
+      return mCurrent == xapian_mset_get_internal (mMSet)->begin ();
     }
 
     bool isEnd () {
       if (!mCurrentInitialized)
         return false;
 
-      return *mCurrent == *mEnd;
+      return !Xapian::iterator_valid (mCurrent);
     }
 
     bool next () {
       if (!mCurrentInitialized)
         {
-          mCurrent = new Xapian::MSetIterator (*mBegin);
+          /* mCurrent was already initialised to the first element by the
+           * constructor. */
           mCurrentInitialized = true;
-          return *mCurrent != *mEnd;
+        }
+      else
+        {
+          g_clear_object (&mDocument);
+
+          ++mCurrent;
         }
 
-      g_clear_object (&mDocument);
-
-      ++(*mCurrent);
-
-      if (*mCurrent == *mEnd)
-        return false;
-
-      return true;
+      return Xapian::iterator_valid (mCurrent);
     }
 
     bool prev () {
       if (!mCurrentInitialized)
         {
-          mCurrent = new Xapian::MSetIterator (*mEnd);
+          /* mCurrent was already initialised to the first element by the
+           * constructor, so we just need to add on the size to point it
+           * to just after the end.
+           */
+          mCurrent += xapian_mset_get_internal (mMSet)->size ();
           mCurrentInitialized = true;
-          return *mCurrent != *mBegin;
+        }
+      else
+        {
+          g_clear_object (&mDocument);
+
+          --mCurrent;
         }
 
-      g_clear_object (&mDocument);
-
-      --(*mCurrent);
-
-      if (*mCurrent == *mBegin)
-        return false;
-
-      return true;
+      return mCurrent != xapian_mset_get_internal (mMSet)->begin ();
     }
 
     unsigned int getRank () {
       if (!mCurrentInitialized)
         return 0;
 
-      return mCurrent->get_rank ();
+      return mCurrent.get_rank ();
     }
 
     double getWeight () {
       if (!mCurrentInitialized)
         return 0;
 
-      return mCurrent->get_weight ();
+      return mCurrent.get_weight ();
     }
 
     double getPercent () {
       if (!mCurrentInitialized)
         return 0;
 
-      return mCurrent->get_percent ();
+      return mCurrent.get_percent ();
     }
 
     XapianDocument * getDocument (GError **error) {
@@ -186,7 +177,7 @@ class IteratorData {
        */
       try
         {
-          Xapian::Document realDoc = mCurrent->get_document ();
+          Xapian::Document realDoc = mCurrent.get_document ();
 
           mDocument = xapian_document_new_from_document (realDoc);
         }
@@ -216,14 +207,14 @@ class IteratorData {
       if (!mCurrentInitialized)
         return 0;
 
-      return mCurrent->get_collapse_count ();
+      return mCurrent.get_collapse_count ();
     }
 
     char * getDescription () {
       if (!mCurrentInitialized)
         return NULL;
 
-      std::string desc = mCurrent->get_description ();
+      std::string desc = mCurrent.get_description ();
 
       return g_strdup (desc.c_str ());
     }
@@ -235,9 +226,7 @@ class IteratorData {
   private:
     XapianMSet *mMSet;
 
-    Xapian::MSetIterator *mBegin;
-    Xapian::MSetIterator *mEnd;
-    Xapian::MSetIterator *mCurrent;
+    Xapian::MSetIterator mCurrent;
 
     bool mCurrentInitialized;
 

--- a/xapian-glib/xapian-mset-iterator.cc
+++ b/xapian-glib/xapian-mset-iterator.cc
@@ -156,7 +156,7 @@ class IteratorData {
       return mCurrent.get_weight ();
     }
 
-    double getPercent () {
+    int getPercent () {
       if (!mCurrentInitialized)
         return 0;
 


### PR DESCRIPTION
Eliminate mBegin and mEnd by using <xapian/iterator.h> and
MSet::begin(), and eliminate an unnecessary pointer indirection
from mCurrent.

Right now, this patch is mostly there for comments, or even just to park it somewhere it won't get lost - it doesn't actually fix bugs as such, rather it simplifies the implementation, reduces the memory overhead (number of memory allocations and total usage) and should be a bit faster.  

But while doing this tweak, I noticed that the semantics of `prev()` seem a bit odd (stemming from the asymmetry of `begin()` and `end()` in C++ - `begin()` points to the first element, but `end()` points to just after the last element).

To iterate forwards, the example code in the docs is:

```
   // retrieve the first 10 results
   XapianMSet *mset = xapian_enquire_get_mset (enquire, 0, 10, NULL);

   unsigned int size = xapian_mset_get_size (mset);

   XapianMSetIterator *iter = xapian_mset_get_begin (mset);

   while (xapian_mset_iterator_next (iter))
     {
       g_print ("Result %u of %u: %.3f [docid=%u]",
                xapian_mset_iterator_get_rank (iter) + 1,
                size,
                xapian_mset_iterator_get_weight (iter),
                xapian_mset_iterator_get_doc_id (iter, NULL));

       XapianDocument *doc = xapian_mset_iterator_get_document (iter, NULL);

       // ... use the document
     }
```

But the equivalent going backwards would be:

```
   // retrieve the first 10 results
   XapianMSet *mset = xapian_enquire_get_mset (enquire, 0, 10, NULL);

   unsigned int size = xapian_mset_get_size (mset);

   XapianMSetIterator *iter = xapian_mset_get_end (mset);

   gboolean more = xapian_mset_iterator_prev (iter);
   while (more)
     {
       more = xapian_mset_iterator_prev (iter);

       g_print ("Result %u of %u: %.3f [docid=%u]",
                xapian_mset_iterator_get_rank (iter) + 1,
                size,
                xapian_mset_iterator_get_weight (iter),
                xapian_mset_iterator_get_doc_id (iter, NULL));

       XapianDocument *doc = xapian_mset_iterator_get_document (iter, NULL);

       // ... use the document
     }
```

The key difference is the loop changes from:

```
 while (xapian_mset_iterator_next (iter))
    {
      // ...
    }
```

to

```
   gboolean more = xapian_mset_iterator_prev (iter);
   while (more)
     {
       more = xapian_mset_iterator_prev (iter);

       // ...
     }
```

Essentially the first time we call `prev()` we get back the end iterator which we must not dereference, but the return value tell us "is the iterated `XapianMSet` non-empty?"

If the first call was OK, subsequent calls always move us to a valid element, and return whether we can safely move back again.

This feels ungainly to work with (it took me several goes to get the second loop right) - is it really intended to work like that?