### PR TITLE
Simplify XapianMSetIterator's IteratorData

### DIFF
--- a/xapian-glib/xapian-mset.h
+++ b/xapian-glib/xapian-mset.h
@@ -116,7 +116,7 @@ XAPIAN_GLIB_AVAILABLE_IN_1_0
 gboolean                xapian_mset_iterator_next               (XapianMSetIterator *iter);
 XAPIAN_GLIB_AVAILABLE_IN_1_0
 gboolean                xapian_mset_iterator_prev               (XapianMSetIterator *iter);
-XAPIAN_GLIB_AVAILABLE_IN_1_0
+XAPIAN_GLIB_DEPRECATED_IN_1_6
 gboolean                xapian_mset_iterator_is_valid           (XapianMSetIterator *iter);
 XAPIAN_GLIB_AVAILABLE_IN_1_0
 gboolean                xapian_mset_iterator_is_begin           (XapianMSetIterator *iter);


### PR DESCRIPTION
These changes match those cosimoc suggested for XapianTermIterator.

The iterator is now always valid, so xapian_mset_iterator_is_valid()
is now deprecated and always returns TRUE.