### PR TITLE
Use G_DECLARE_* macro for Xapian wrapper types

### DIFF
--- a/xapian-glib/xapian-database.h
+++ b/xapian-glib/xapian-database.h
@@ -23,31 +23,21 @@
 #endif
 
 #include "xapian-glib-types.h"
+#include "xapian-document.h"
+#include "xapian-term-iterator.h"
 
 G_BEGIN_DECLS
 
-#define XAPIAN_DATABASE(obj)            (G_TYPE_CHECK_INSTANCE_CAST ((obj), XAPIAN_TYPE_DATABASE, XapianDatabase))
-#define XAPIAN_IS_DATABASE(obj)         (G_TYPE_CHECK_INSTANCE_TYPE ((obj), XAPIAN_TYPE_DATABASE))
-#define XAPIAN_DATABASE_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST ((klass), XAPIAN_TYPE_DATABASE, XapianDatabaseClass))
-#define XAPIAN_IS_DATABASE_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE ((klass), XAPIAN_TYPE_DATABASE))
-#define XAPIAN_DATABASE_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS ((obj), XAPIAN_TYPE_DATABASE, XapianDatabaseClass))
+#define XAPIAN_TYPE_DATABASE    (xapian_database_get_type())
 
-typedef struct _XapianDatabaseClass     XapianDatabaseClass;
-
-struct _XapianDatabase
-{
-  /*< private >*/
-  GObject parent_instance;
-};
+XAPIAN_GLIB_AVAILABLE_IN_1_0
+G_DECLARE_DERIVABLE_TYPE (XapianDatabase, xapian_database, XAPIAN, DATABASE, GObject)
 
 struct _XapianDatabaseClass
 {
   /*< private >*/
-  GObjectClass parent_instance;
+  GObjectClass parent_class;
 };
-
-XAPIAN_GLIB_AVAILABLE_IN_1_0
-GType xapian_database_get_type (void);
 
 XAPIAN_GLIB_AVAILABLE_IN_1_0
 XapianDatabase *        xapian_database_new             (GError        **error);

--- a/xapian-glib/xapian-document.h
+++ b/xapian-glib/xapian-document.h
@@ -25,26 +25,16 @@
 
 G_BEGIN_DECLS
 
-#define XAPIAN_DOCUMENT(obj)            (G_TYPE_CHECK_INSTANCE_CAST ((obj), XAPIAN_TYPE_DOCUMENT, XapianDocument))
-#define XAPIAN_IS_DOCUMENT(obj)         (G_TYPE_CHECK_INSTANCE_TYPE ((obj), XAPIAN_TYPE_DOCUMENT))
-#define XAPIAN_DOCUMENT_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST ((klass), XAPIAN_TYPE_DOCUMENT, XapianDocumentClass))
-#define XAPIAN_IS_DOCUMENT_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE ((klass), XAPIAN_TYPE_DOCUMENT))
-#define XAPIAN_DOCUMENT_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS ((obj), XAPIAN_TYPE_DOCUMENT, XapianDocumentClass))
+#define XAPIAN_TYPE_DOCUMENT    (xapian_document_get_type())
 
-typedef struct _XapianDocumentClass     XapianDocumentClass;
-
-struct _XapianDocument
-{
-  GObject parent_instance;
-};
+XAPIAN_GLIB_AVAILABLE_IN_1_0
+G_DECLARE_DERIVABLE_TYPE (XapianDocument, xapian_document, XAPIAN, DOCUMENT, GObject)
 
 struct _XapianDocumentClass
 {
-  GObjectClass parent_instance;
+  /*< private >*/
+  GObjectClass parent_class;
 };
-
-XAPIAN_GLIB_AVAILABLE_IN_1_0
-GType xapian_document_get_type (void);
 
 XAPIAN_GLIB_AVAILABLE_IN_1_0
 XapianDocument *        xapian_document_new                     (void);

--- a/xapian-glib/xapian-enquire.h
+++ b/xapian-glib/xapian-enquire.h
@@ -22,29 +22,21 @@
 #endif
 
 #include "xapian-glib-types.h"
+#include "xapian-database.h"
+#include "xapian-query.h"
+#include "xapian-mset.h"
 
 G_BEGIN_DECLS
 
-#define XAPIAN_ENQUIRE(obj)             (G_TYPE_CHECK_INSTANCE_CAST ((obj), XAPIAN_TYPE_ENQUIRE, XapianEnquire))
-#define XAPIAN_IS_ENQUIRE(obj)          (G_TYPE_CHECK_INSTANCE_TYPE ((obj), XAPIAN_TYPE_ENQUIRE))
-#define XAPIAN_ENQUIRE_CLASS(klass)     (G_TYPE_CHECK_CLASS_CAST ((klass), XAPIAN_TYPE_ENQUIRE, XapianEnquireClass))
-#define XAPIAN_IS_ENQUIRE_CLASS(klass)  (G_TYPE_CHECK_CLASS_TYPE ((klass), XAPIAN_TYPE_ENQUIRE))
-#define XAPIAN_ENQUIRE_GET_CLASS(obj)   (G_TYPE_INSTANCE_GET_CLASS ((obj), XAPIAN_TYPE_ENQUIRE, XapianEnquireClass))
+#define XAPIAN_TYPE_ENQUIRE     (xapian_enquire_get_type())
 
-typedef struct _XapianEnquireClass      XapianEnquireClass;
-
-struct _XapianEnquire
-{
-  GObject parent_instance;
-};
+XAPIAN_GLIB_AVAILABLE_IN_1_0
+G_DECLARE_DERIVABLE_TYPE (XapianEnquire, xapian_enquire, XAPIAN, ENQUIRE, GObject)
 
 struct _XapianEnquireClass
 {
   GObjectClass parent_instance;
 };
-
-XAPIAN_GLIB_AVAILABLE_IN_1_0
-GType xapian_enquire_get_type (void);
 
 XAPIAN_GLIB_AVAILABLE_IN_1_0
 XapianEnquire * xapian_enquire_new                    (XapianDatabase *db,

--- a/xapian-glib/xapian-glib-types.h
+++ b/xapian-glib/xapian-glib-types.h
@@ -22,45 +22,4 @@
 #include "xapian-glib-macros.h"
 #include "xapian-enums.h"
 
-G_BEGIN_DECLS
-
-#define XAPIAN_TYPE_DATABASE                    (xapian_database_get_type ())
-#define XAPIAN_TYPE_WRITABLE_DATABASE           (xapian_writable_database_get_type ())
-#define XAPIAN_TYPE_DOCUMENT                    (xapian_document_get_type ())
-#define XAPIAN_TYPE_ENQUIRE                     (xapian_enquire_get_type ())
-#define XAPIAN_TYPE_POSTING_SOURCE              (xapian_posting_source_get_type ())
-#define XAPIAN_TYPE_VALUE_POSTING_SOURCE        (xapian_value_posting_source_get_type ())
-#define XAPIAN_TYPE_VALUE_WEIGHT_POSTING_SOURCE (xapian_value_weight_posting_source_get_type ())
-#define XAPIAN_TYPE_QUERY                       (xapian_query_get_type ())
-#define XAPIAN_TYPE_STEM                        (xapian_stem_get_type ())
-#define XAPIAN_TYPE_QUERY_PARSER                (xapian_query_parser_get_type ())
-#define XAPIAN_TYPE_MSET                        (xapian_mset_get_type ())
-#define XAPIAN_TYPE_MSET_ITERATOR               (xapian_mset_iterator_get_type ())
-#define XAPIAN_TYPE_SIMPLE_STOPPER              (xapian_simple_stopper_get_type ())
-#define XAPIAN_TYPE_STOPPER                     (xapian_stopper_get_type ())
-#define XAPIAN_TYPE_TERM_GENERATOR              (xapian_term_generator_get_type ())
-#define XAPIAN_TYPE_TERM_ITERATOR               (xapian_term_iterator_get_type ())
-
-typedef struct _XapianDatabase                  XapianDatabase;
-typedef struct _XapianWritableDatabase          XapianWritableDatabase;
-
-typedef struct _XapianDocument                  XapianDocument;
-
-typedef struct _XapianEnquire                   XapianEnquire;
-typedef struct _XapianPostingSource             XapianPostingSource;
-typedef struct _XapianValuePostingSource        XapianValuePostingSource;
-typedef struct _XapianValueWeightPostingSource  XapianValueWeightPostingSource;
-typedef struct _XapianQuery                     XapianQuery;
-typedef struct _XapianStem                      XapianStem;
-typedef struct _XapianQueryParser               XapianQueryParser;
-typedef struct _XapianMSet                      XapianMSet;
-typedef struct _XapianMSetIterator              XapianMSetIterator;
-
-typedef struct _XapianSimpleStopper             XapianSimpleStopper;
-typedef struct _XapianStopper                   XapianStopper;
-typedef struct _XapianTermGenerator             XapianTermGenerator;
-typedef struct _XapianTermIterator              XapianTermIterator;
-
-G_END_DECLS
-
 #endif /* __XAPIAN_GLIB_TYPES_H__ */

--- a/xapian-glib/xapian-mset.h
+++ b/xapian-glib/xapian-mset.h
@@ -22,33 +22,26 @@
 #endif
 
 #include "xapian-glib-types.h"
+#include "xapian-document.h"
 
 G_BEGIN_DECLS
 
+#define XAPIAN_TYPE_MSET                (xapian_mset_get_type())
+#define XAPIAN_TYPE_MSET_ITERATOR       (xapian_mset_iterator_get_type())
+
+XAPIAN_GLIB_AVAILABLE_IN_1_0
+G_DECLARE_DERIVABLE_TYPE (XapianMSet, xapian_mset, XAPIAN, MSET, GObject)
+
+XAPIAN_GLIB_AVAILABLE_IN_1_0
+G_DECLARE_DERIVABLE_TYPE (XapianMSetIterator, xapian_mset_iterator, XAPIAN, MSET_ITERATOR, GObject)
+
 /* MSet */
-
-#define XAPIAN_MSET(obj)                (G_TYPE_CHECK_INSTANCE_CAST ((obj), XAPIAN_TYPE_MSET, XapianMSet))
-#define XAPIAN_IS_MSET(obj)             (G_TYPE_CHECK_INSTANCE_TYPE ((obj), XAPIAN_TYPE_MSET))
-#define XAPIAN_MSET_CLASS(klass)        (G_TYPE_CHECK_CLASS_CAST ((klass), XAPIAN_TYPE_MSET, XapianMSetClass))
-#define XAPIAN_IS_MSET_CLASS(klass)     (G_TYPE_CHECK_CLASS_TYPE ((klass), XAPIAN_TYPE_MSET))
-#define XAPIAN_MSET_GET_CLASS(obj)      (G_TYPE_INSTANCE_GET_CLASS ((obj), XAPIAN_TYPE_MSET, XapianMSetClass))
-
-typedef struct _XapianMSetClass         XapianMSetClass;
-
-struct _XapianMSet
-{
-  /*< private >*/
-  GObject parent_instance;
-};
 
 struct _XapianMSetClass
 {
   /*< private >*/
   GObjectClass parent_instance;
 };
-
-XAPIAN_GLIB_AVAILABLE_IN_1_0
-GType xapian_mset_get_type (void);
 
 XAPIAN_GLIB_AVAILABLE_IN_1_0
 unsigned int            xapian_mset_get_firstitem                               (XapianMSet *mset);
@@ -86,31 +79,13 @@ XapianMSetIterator *    xapian_mset_get_begin                                   
 XAPIAN_GLIB_AVAILABLE_IN_1_0
 XapianMSetIterator *    xapian_mset_get_end                                     (XapianMSet *mset);
 
-
 /* Iterator */
-
-#define XAPIAN_MSET_ITERATOR(obj)                (G_TYPE_CHECK_INSTANCE_CAST ((obj), XAPIAN_TYPE_MSET_ITERATOR, XapianMSetIterator))
-#define XAPIAN_IS_MSET_ITERATOR(obj)             (G_TYPE_CHECK_INSTANCE_TYPE ((obj), XAPIAN_TYPE_MSET_ITERATOR))
-#define XAPIAN_MSET_ITERATOR_CLASS(klass)        (G_TYPE_CHECK_CLASS_CAST ((klass), XAPIAN_TYPE_MSET_ITERATOR, XapianMSetIteratorClass))
-#define XAPIAN_IS_MSET_ITERATOR_CLASS(klass)     (G_TYPE_CHECK_CLASS_TYPE ((klass), XAPIAN_TYPE_MSET_ITERATOR))
-#define XAPIAN_MSET_ITERATOR_GET_CLASS(obj)      (G_TYPE_INSTANCE_GET_CLASS ((obj), XAPIAN_TYPE_MSET_ITERATOR, XapianMSetIteratorClass))
-
-typedef struct _XapianMSetIteratorClass XapianMSetIteratorClass;
-
-struct _XapianMSetIterator
-{
-  /*< private >*/
-  GObject parent_instance;
-};
 
 struct _XapianMSetIteratorClass
 {
   /*< private >*/
   GObjectClass parent_instance;
 };
-
-XAPIAN_GLIB_AVAILABLE_IN_1_0
-GType xapian_mset_iterator_get_type (void);
 
 XAPIAN_GLIB_AVAILABLE_IN_1_0
 gboolean                xapian_mset_iterator_next               (XapianMSetIterator *iter);

--- a/xapian-glib/xapian-posting-source.h
+++ b/xapian-glib/xapian-posting-source.h
@@ -25,27 +25,15 @@
 
 G_BEGIN_DECLS
 
-#define XAPIAN_POSTING_SOURCE(obj)             (G_TYPE_CHECK_INSTANCE_CAST ((obj), XAPIAN_TYPE_POSTING_SOURCE, XapianPostingSource))
-#define XAPIAN_IS_POSTING_SOURCE(obj)          (G_TYPE_CHECK_INSTANCE_TYPE ((obj), XAPIAN_TYPE_POSTING_SOURCE))
-#define XAPIAN_POSTING_SOURCE_CLASS(klass)     (G_TYPE_CHECK_CLASS_CAST ((klass), XAPIAN_TYPE_POSTING_SOURCE, XapianPostingSourceClass))
-#define XAPIAN_IS_POSTING_SOURCE_CLASS(klass)  (G_TYPE_CHECK_CLASS_TYPE ((klass), XAPIAN_TYPE_POSTING_SOURCE))
-#define XAPIAN_POSTING_SOURCE_GET_CLASS(obj)   (G_TYPE_INSTANCE_GET_CLASS ((obj), XAPIAN_TYPE_POSTING_SOURCE, XapianPostingSourceClass))
+#define XAPIAN_TYPE_POSTING_SOURCE      (xapian_posting_source_get_type())
 
-typedef struct _XapianPostingSource           XapianPostingSource;
-typedef struct _XapianPostingSourceClass      XapianPostingSourceClass;
-
-struct _XapianPostingSource
-{
-  GObject parent_instance;
-};
+XAPIAN_GLIB_AVAILABLE_IN_1_2
+G_DECLARE_DERIVABLE_TYPE (XapianPostingSource, xapian_posting_source, XAPIAN, POSTING_SOURCE, GObject)
 
 struct _XapianPostingSourceClass
 {
   GObjectClass parent_instance;
 };
-
-XAPIAN_GLIB_AVAILABLE_IN_1_2
-GType xapian_posting_source_get_type (void);
 
 XAPIAN_GLIB_AVAILABLE_IN_1_2
 char *xapian_posting_source_get_description (XapianPostingSource *self);

--- a/xapian-glib/xapian-query-parser.h
+++ b/xapian-glib/xapian-query-parser.h
@@ -22,29 +22,22 @@
 #endif
 
 #include "xapian-glib-types.h"
+#include "xapian-database.h"
+#include "xapian-query.h"
+#include "xapian-stem.h"
+#include "xapian-stopper.h"
 
 G_BEGIN_DECLS
 
-#define XAPIAN_QUERY_PARSER(obj)                (G_TYPE_CHECK_INSTANCE_CAST ((obj), XAPIAN_TYPE_QUERY_PARSER, XapianQueryParser))
-#define XAPIAN_IS_QUERY_PARSER(obj)             (G_TYPE_CHECK_INSTANCE_TYPE ((obj), XAPIAN_TYPE_QUERY_PARSER))
-#define XAPIAN_QUERY_PARSER_CLASS(klass)        (G_TYPE_CHECK_CLASS_CAST ((klass), XAPIAN_TYPE_QUERY_PARSER, XapianQueryParserClass))
-#define XAPIAN_IS_QUERY_PARSER_CLASS(klass)     (G_TYPE_CHECK_CLASS_TYPE ((klass), XAPIAN_TYPE_QUERY_PARSER))
-#define XAPIAN_QUERY_PARSER_GET_CLASS(obj)      (G_TYPE_INSTANCE_GET_CLASS ((obj), XAPIAN_TYPE_QUERY_PARSER, XapianQueryParserClass))
+#define XAPIAN_TYPE_QUERY_PARSER        (xapian_query_parser_get_type())
 
-typedef struct _XapianQueryParserClass     XapianQueryParserClass;
-
-struct _XapianQueryParser
-{
-  GObject parent_instance;
-};
+XAPIAN_GLIB_AVAILABLE_IN_1_0
+G_DECLARE_DERIVABLE_TYPE (XapianQueryParser, xapian_query_parser, XAPIAN, QUERY_PARSER, GObject)
 
 struct _XapianQueryParserClass
 {
   GObjectClass parent_instance;
 };
-
-XAPIAN_GLIB_AVAILABLE_IN_1_0
-GType xapian_query_parser_get_type (void);
 
 XAPIAN_GLIB_AVAILABLE_IN_1_0
 XapianQueryParser *     xapian_query_parser_new                         (void);

--- a/xapian-glib/xapian-query.h
+++ b/xapian-glib/xapian-query.h
@@ -22,29 +22,19 @@
 #endif
 
 #include "xapian-glib-types.h"
+#include "xapian-posting-source.h"
 
 G_BEGIN_DECLS
 
-#define XAPIAN_QUERY(obj)               (G_TYPE_CHECK_INSTANCE_CAST ((obj), XAPIAN_TYPE_QUERY, XapianQuery))
-#define XAPIAN_IS_QUERY(obj)            (G_TYPE_CHECK_INSTANCE_TYPE ((obj), XAPIAN_TYPE_QUERY))
-#define XAPIAN_QUERY_CLASS(klass)       (G_TYPE_CHECK_CLASS_CAST ((klass), XAPIAN_TYPE_QUERY, XapianQueryClass))
-#define XAPIAN_IS_QUERY_CLASS(klass)    (G_TYPE_CHECK_CLASS_TYPE ((klass), XAPIAN_TYPE_QUERY))
-#define XAPIAN_QUERY_GET_CLASS(obj)     (G_TYPE_INSTANCE_GET_CLASS ((obj), XAPIAN_TYPE_QUERY, XapianQueryClass))
+#define XAPIAN_TYPE_QUERY       (xapian_query_get_type())
 
-typedef struct _XapianQueryClass     XapianQueryClass;
-
-struct _XapianQuery
-{
-  GObject parent_instance;
-};
+XAPIAN_GLIB_AVAILABLE_IN_1_0
+G_DECLARE_DERIVABLE_TYPE (XapianQuery, xapian_query, XAPIAN, QUERY, GObject)
 
 struct _XapianQueryClass
 {
   GObjectClass parent_instance;
 };
-
-XAPIAN_GLIB_AVAILABLE_IN_1_0
-GType xapian_query_get_type (void);
 
 XAPIAN_GLIB_AVAILABLE_IN_1_0
 XapianQuery *   xapian_query_new                (void);

--- a/xapian-glib/xapian-simple-stopper.h
+++ b/xapian-glib/xapian-simple-stopper.h
@@ -26,19 +26,10 @@
 
 G_BEGIN_DECLS
 
-#define XAPIAN_SIMPLE_STOPPER(obj)             (G_TYPE_CHECK_INSTANCE_CAST ((obj), XAPIAN_TYPE_SIMPLE_STOPPER, XapianSimpleStopper))
-#define XAPIAN_IS_SIMPLE_STOPPER(obj)          (G_TYPE_CHECK_INSTANCE_TYPE ((obj), XAPIAN_TYPE_SIMPLE_STOPPER))
-#define XAPIAN_SIMPLE_STOPPER_CLASS(klass)     (G_TYPE_CHECK_CLASS_CAST ((klass), XAPIAN_TYPE_SIMPLE_STOPPER, XapianSimpleStopperClass))
-#define XAPIAN_IS_SIMPLE_STOPPER_CLASS(klass)  (G_TYPE_CHECK_CLASS_TYPE ((klass), XAPIAN_TYPE_SIMPLE_STOPPER))
-#define XAPIAN_SIMPLE_STOPPER_GET_CLASS(obj)   (G_TYPE_INSTANCE_GET_CLASS ((obj), XAPIAN_TYPE_SIMPLE_STOPPER, XapianSimpleStopperClass))
+#define XAPIAN_TYPE_SIMPLE_STOPPER      (xapian_simple_stopper_get_type())
 
-typedef struct _XapianSimpleStopper           XapianSimpleStopper;
-typedef struct _XapianSimpleStopperClass      XapianSimpleStopperClass;
-
-struct _XapianSimpleStopper
-{
-  XapianStopper parent_instance;
-};
+XAPIAN_GLIB_AVAILABLE_IN_1_2
+G_DECLARE_DERIVABLE_TYPE (XapianSimpleStopper, xapian_simple_stopper, XAPIAN, SIMPLE_STOPPER, XapianStopper)
 
 struct _XapianSimpleStopperClass
 {
@@ -46,10 +37,7 @@ struct _XapianSimpleStopperClass
 };
 
 XAPIAN_GLIB_AVAILABLE_IN_1_2
-GType xapian_simple_stopper_get_type (void);
-
-XAPIAN_GLIB_AVAILABLE_IN_1_2
-XapianSimpleStopper * xapian_simple_stopper_new ();
+XapianSimpleStopper * xapian_simple_stopper_new (void);
 
 
 XAPIAN_GLIB_AVAILABLE_IN_1_2

--- a/xapian-glib/xapian-stem.h
+++ b/xapian-glib/xapian-stem.h
@@ -25,12 +25,6 @@
 
 G_BEGIN_DECLS
 
-#define XAPIAN_STEM(obj)                (G_TYPE_CHECK_INSTANCE_CAST ((obj), XAPIAN_TYPE_STEM, XapianStem))
-#define XAPIAN_IS_STEM(obj)             (G_TYPE_CHECK_INSTANCE_TYPE ((obj), XAPIAN_TYPE_STEM))
-#define XAPIAN_STEM_CLASS(klass)        (G_TYPE_CHECK_CLASS_CAST ((klass), XAPIAN_TYPE_STEM, XapianStemClass))
-#define XAPIAN_IS_STEM_CLASS(klass)     (G_TYPE_CHECK_CLASS_TYPE ((klass), XAPIAN_TYPE_STEM))
-#define XAPIAN_STEM_GET_CLASS(obj)      (G_TYPE_INSTANCE_GET_CLASS ((obj), XAPIAN_TYPE_STEM, XapianStemClass))
-
 /**
  * XAPIAN_STEM_LANGUAGE_NONE:
  *
@@ -38,20 +32,15 @@ G_BEGIN_DECLS
  */
 #define XAPIAN_STEM_LANGUAGE_NONE       "none"
 
-typedef struct _XapianStemClass         XapianStemClass;
+#define XAPIAN_TYPE_STEM        (xapian_stem_get_type())
 
-struct _XapianStem
-{
-  GObject parent_instance;
-};
+XAPIAN_GLIB_AVAILABLE_IN_1_0
+G_DECLARE_DERIVABLE_TYPE (XapianStem, xapian_stem, XAPIAN, STEM, GObject)
 
 struct _XapianStemClass
 {
   GObjectClass parent_instance;
 };
-
-XAPIAN_GLIB_AVAILABLE_IN_1_0
-GType xapian_stem_get_type (void);
 
 XAPIAN_GLIB_AVAILABLE_IN_1_0
 XapianStem *    xapian_stem_new                         (void);

--- a/xapian-glib/xapian-stopper.h
+++ b/xapian-glib/xapian-stopper.h
@@ -25,19 +25,10 @@
 
 G_BEGIN_DECLS
 
-#define XAPIAN_STOPPER(obj)             (G_TYPE_CHECK_INSTANCE_CAST ((obj), XAPIAN_TYPE_STOPPER, XapianStopper))
-#define XAPIAN_IS_STOPPER(obj)          (G_TYPE_CHECK_INSTANCE_TYPE ((obj), XAPIAN_TYPE_STOPPER))
-#define XAPIAN_STOPPER_CLASS(klass)     (G_TYPE_CHECK_CLASS_CAST ((klass), XAPIAN_TYPE_STOPPER, XapianStopperClass))
-#define XAPIAN_IS_STOPPER_CLASS(klass)  (G_TYPE_CHECK_CLASS_TYPE ((klass), XAPIAN_TYPE_STOPPER))
-#define XAPIAN_STOPPER_GET_CLASS(obj)   (G_TYPE_INSTANCE_GET_CLASS ((obj), XAPIAN_TYPE_STOPPER, XapianStopperClass))
+#define XAPIAN_TYPE_STOPPER     (xapian_stopper_get_type())
 
-typedef struct _XapianStopper           XapianStopper;
-typedef struct _XapianStopperClass      XapianStopperClass;
-
-struct _XapianStopper
-{
-  GObject parent_instance;
-};
+XAPIAN_GLIB_AVAILABLE_IN_1_2
+G_DECLARE_DERIVABLE_TYPE (XapianStopper, xapian_stopper, XAPIAN, STOPPER, GObject)
 
 /**
  * XapianStopperClass:
@@ -63,9 +54,6 @@ struct _XapianStopperClass
   /*< private >*/
   gpointer _padding[8];
 };
-
-XAPIAN_GLIB_AVAILABLE_IN_1_2
-GType xapian_stopper_get_type (void);
 
 XAPIAN_GLIB_AVAILABLE_IN_1_2
 gchar *         xapian_stopper_get_description  (XapianStopper *self);

--- a/xapian-glib/xapian-term-generator.h
+++ b/xapian-glib/xapian-term-generator.h
@@ -22,29 +22,21 @@
 #endif
 
 #include "xapian-glib-types.h"
+#include "xapian-stem.h"
+#include "xapian-stopper.h"
+#include "xapian-writable-database.h"
 
 G_BEGIN_DECLS
 
-#define XAPIAN_TERM_GENERATOR(obj)              (G_TYPE_CHECK_INSTANCE_CAST ((obj), XAPIAN_TYPE_TERM_GENERATOR, XapianTermGenerator))
-#define XAPIAN_IS_TERM_GENERATOR(obj)           (G_TYPE_CHECK_INSTANCE_TYPE ((obj), XAPIAN_TYPE_TERM_GENERATOR))
-#define XAPIAN_TERM_GENERATOR_CLASS(klass)      (G_TYPE_CHECK_CLASS_CAST ((klass), XAPIAN_TYPE_TERM_GENERATOR, XapianTermGeneratorClass))
-#define XAPIAN_IS_TERM_GENERATOR_CLASS(klass)   (G_TYPE_CHECK_CLASS_TYPE ((klass), XAPIAN_TYPE_TERM_GENERATOR))
-#define XAPIAN_TERM_GENERATOR_GET_CLASS(obj)    (G_TYPE_INSTANCE_GET_CLASS ((obj), XAPIAN_TYPE_TERM_GENERATOR, XapianTermGeneratorClass))
+#define XAPIAN_TYPE_TERM_GENERATOR      (xapian_term_generator_get_type())
 
-typedef struct _XapianTermGeneratorClass     XapianTermGeneratorClass;
-
-struct _XapianTermGenerator
-{
-  GObject parent_instance;
-};
+XAPIAN_GLIB_AVAILABLE_IN_1_0
+G_DECLARE_DERIVABLE_TYPE (XapianTermGenerator, xapian_term_generator, XAPIAN, TERM_GENERATOR, GObject)
 
 struct _XapianTermGeneratorClass
 {
   GObjectClass parent_instance;
 };
-
-XAPIAN_GLIB_AVAILABLE_IN_1_0
-GType xapian_term_generator_get_type (void);
 
 XAPIAN_GLIB_AVAILABLE_IN_1_0
 XapianTermGenerator *   xapian_term_generator_new       (void);

--- a/xapian-glib/xapian-term-iterator.h
+++ b/xapian-glib/xapian-term-iterator.h
@@ -25,30 +25,16 @@
 
 G_BEGIN_DECLS
 
-/* Iterator */
+#define XAPIAN_TYPE_TERM_ITERATOR               (xapian_term_iterator_get_type ())
 
-#define XAPIAN_TERM_ITERATOR(obj)                (G_TYPE_CHECK_INSTANCE_CAST ((obj), XAPIAN_TYPE_TERM_ITERATOR, XapianTermIterator))
-#define XAPIAN_IS_TERM_ITERATOR(obj)             (G_TYPE_CHECK_INSTANCE_TYPE ((obj), XAPIAN_TYPE_TERM_ITERATOR))
-#define XAPIAN_TERM_ITERATOR_CLASS(klass)        (G_TYPE_CHECK_CLASS_CAST ((klass), XAPIAN_TYPE_TERM_ITERATOR, XapianTermIteratorClass))
-#define XAPIAN_IS_TERM_ITERATOR_CLASS(klass)     (G_TYPE_CHECK_CLASS_TYPE ((klass), XAPIAN_TYPE_TERM_ITERATOR))
-#define XAPIAN_TERM_ITERATOR_GET_CLASS(obj)      (G_TYPE_INSTANCE_GET_CLASS ((obj), XAPIAN_TYPE_TERM_ITERATOR, XapianTermIteratorClass))
-
-typedef struct _XapianTermIteratorClass XapianTermIteratorClass;
-
-struct _XapianTermIterator
-{
-  /*< private >*/
-  GObject parent_instance;
-};
+XAPIAN_GLIB_AVAILABLE_IN_1_6
+G_DECLARE_DERIVABLE_TYPE (XapianTermIterator, xapian_term_iterator, XAPIAN, TERM_ITERATOR, GObject)
 
 struct _XapianTermIteratorClass
 {
   /*< private >*/
   GObjectClass parent_instance;
 };
-
-XAPIAN_GLIB_AVAILABLE_IN_1_6
-GType xapian_term_iterator_get_type (void);
 
 XAPIAN_GLIB_AVAILABLE_IN_1_6
 gboolean                xapian_term_iterator_next               (XapianTermIterator *iter);

--- a/xapian-glib/xapian-value-posting-source.h
+++ b/xapian-glib/xapian-value-posting-source.h
@@ -26,27 +26,15 @@
 
 G_BEGIN_DECLS
 
-#define XAPIAN_VALUE_POSTING_SOURCE(obj)             (G_TYPE_CHECK_INSTANCE_CAST ((obj), XAPIAN_TYPE_VALUE_POSTING_SOURCE, XapianValuePostingSource))
-#define XAPIAN_IS_VALUE_POSTING_SOURCE(obj)          (G_TYPE_CHECK_INSTANCE_TYPE ((obj), XAPIAN_TYPE_VALUE_POSTING_SOURCE))
-#define XAPIAN_VALUE_POSTING_SOURCE_CLASS(klass)     (G_TYPE_CHECK_CLASS_CAST ((klass), XAPIAN_TYPE_VALUE_POSTING_SOURCE, XapianValuePostingSourceClass))
-#define XAPIAN_IS_VALUE_POSTING_SOURCE_CLASS(klass)  (G_TYPE_CHECK_CLASS_TYPE ((klass), XAPIAN_TYPE_VALUE_POSTING_SOURCE))
-#define XAPIAN_VALUE_POSTING_SOURCE_GET_CLASS(obj)   (G_TYPE_INSTANCE_GET_CLASS ((obj), XAPIAN_TYPE_VALUE_POSTING_SOURCE, XapianValuePostingSourceClass))
+#define XAPIAN_TYPE_VALUE_POSTING_SOURCE        (xapian_value_posting_source_get_type())
 
-typedef struct _XapianValuePostingSource           XapianValuePostingSource;
-typedef struct _XapianValuePostingSourceClass      XapianValuePostingSourceClass;
-
-struct _XapianValuePostingSource
-{
-  XapianPostingSource parent_instance;
-};
+XAPIAN_GLIB_AVAILABLE_IN_1_2
+G_DECLARE_DERIVABLE_TYPE (XapianValuePostingSource, xapian_value_posting_source, XAPIAN, VALUE_POSTING_SOURCE, XapianPostingSource)
 
 struct _XapianValuePostingSourceClass
 {
   XapianPostingSourceClass parent_instance;
 };
-
-XAPIAN_GLIB_AVAILABLE_IN_1_2
-GType xapian_value_posting_source_get_type (void);
 
 XAPIAN_GLIB_AVAILABLE_IN_1_2
 XapianValuePostingSource * xapian_value_posting_source_new (unsigned int   slot,

--- a/xapian-glib/xapian-value-weight-posting-source.h
+++ b/xapian-glib/xapian-value-weight-posting-source.h
@@ -26,27 +26,17 @@
 
 G_BEGIN_DECLS
 
-#define XAPIAN_VALUE_WEIGHT_POSTING_SOURCE(obj)             (G_TYPE_CHECK_INSTANCE_CAST ((obj), XAPIAN_TYPE_VALUE_WEIGHT_POSTING_SOURCE, XapianValueWeightPostingSource))
-#define XAPIAN_IS_VALUE_WEIGHT_POSTING_SOURCE(obj)          (G_TYPE_CHECK_INSTANCE_TYPE ((obj), XAPIAN_TYPE_VALUE_WEIGHT_POSTING_SOURCE))
-#define XAPIAN_VALUE_WEIGHT_POSTING_SOURCE_CLASS(klass)     (G_TYPE_CHECK_CLASS_CAST ((klass), XAPIAN_TYPE_VALUE_WEIGHT_POSTING_SOURCE, XapianValueWeightPostingSourceClass))
-#define XAPIAN_IS_VALUE_WEIGHT_POSTING_SOURCE_CLASS(klass)  (G_TYPE_CHECK_CLASS_TYPE ((klass), XAPIAN_TYPE_VALUE_WEIGHT_POSTING_SOURCE))
-#define XAPIAN_VALUE_WEIGHT_POSTING_SOURCE_GET_CLASS(obj)   (G_TYPE_INSTANCE_GET_CLASS ((obj), XAPIAN_TYPE_VALUE_WEIGHT_POSTING_SOURCE, XapianValueWeightPostingSourceClass))
+#define XAPIAN_TYPE_VALUE_WEIGHT_POSTING_SOURCE (xapian_value_weight_posting_source_get_type())
 
-typedef struct _XapianValueWeightPostingSource           XapianValueWeightPostingSource;
-typedef struct _XapianValueWeightPostingSourceClass      XapianValueWeightPostingSourceClass;
-
-struct _XapianValueWeightPostingSource
-{
-  XapianValuePostingSource parent_instance;
-};
+XAPIAN_GLIB_AVAILABLE_IN_1_2
+G_DECLARE_DERIVABLE_TYPE (XapianValueWeightPostingSource, xapian_value_weight_posting_source,
+                          XAPIAN, VALUE_WEIGHT_POSTING_SOURCE,
+                          XapianValuePostingSource)
 
 struct _XapianValueWeightPostingSourceClass
 {
   XapianValuePostingSourceClass parent_instance;
 };
-
-XAPIAN_GLIB_AVAILABLE_IN_1_2
-GType xapian_value_weight_posting_source_get_type (void);
 
 XAPIAN_GLIB_AVAILABLE_IN_1_2
 XapianValueWeightPostingSource * xapian_value_weight_posting_source_new (unsigned int slot,

--- a/xapian-glib/xapian-writable-database.h
+++ b/xapian-glib/xapian-writable-database.h
@@ -26,26 +26,16 @@
 
 G_BEGIN_DECLS
 
-#define XAPIAN_WRITABLE_DATABASE(obj)            (G_TYPE_CHECK_INSTANCE_CAST ((obj), XAPIAN_TYPE_WRITABLE_DATABASE, XapianWritableDatabase))
-#define XAPIAN_IS_WRITABLE_DATABASE(obj)         (G_TYPE_CHECK_INSTANCE_TYPE ((obj), XAPIAN_TYPE_WRITABLE_DATABASE))
-#define XAPIAN_WRITABLE_DATABASE_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST ((klass), XAPIAN_TYPE_WRITABLE_DATABASE, XapianWritableDatabaseClass))
-#define XAPIAN_IS_WRITABLE_DATABASE_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE ((klass), XAPIAN_TYPE_WRITABLE_DATABASE))
-#define XAPIAN_WRITABLE_DATABASE_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS ((obj), XAPIAN_TYPE_WRITABLE_DATABASE, XapianWritableDatabaseClass))
+#define XAPIAN_TYPE_WRITABLE_DATABASE   (xapian_writable_database_get_type())
 
-typedef struct _XapianWritableDatabaseClass     XapianWritableDatabaseClass;
-
-struct _XapianWritableDatabase
-{
-  XapianDatabase parent_instance;
-};
+XAPIAN_GLIB_AVAILABLE_IN_1_0
+G_DECLARE_DERIVABLE_TYPE (XapianWritableDatabase, xapian_writable_database, XAPIAN, WRITABLE_DATABASE, XapianDatabase)
 
 struct _XapianWritableDatabaseClass
 {
-  XapianDatabaseClass parent_instance;
+  /*< private >*/
+  XapianDatabaseClass parent_class;
 };
-
-XAPIAN_GLIB_AVAILABLE_IN_1_0
-GType xapian_writable_database_get_type (void);
 
 XAPIAN_GLIB_AVAILABLE_IN_1_0
 XapianWritableDatabase *        xapian_writable_database_new                    (const char            *path,


### PR DESCRIPTION
The main benefit of this macro is that it cuts down the boilerplate
needed by GObject classes; additionally, though, it automatically
creates the g_autoptr definitions for us.

https://phabricator.endlessm.com/T19193