### PR TITLE
build: Use 'meson test' instead of 'mesontest'

### DIFF
--- a/configure
+++ b/configure
@@ -52,7 +52,6 @@ sanitycheck() {
 }
 
 sanitycheck MESON 'meson'
-sanitycheck MESONTEST 'mesontest'
 sanitycheck NINJA 'ninja' 'ninja-build'
 
 enable_docs='-Dbuild_docs=false'
@@ -115,7 +114,7 @@ install:
 	DESTDIR="\$(DESTDIR)" ${NINJA} ${NINJA_OPT} install
 
 check:
-	${MESONTEST} ${NINJA_OPT}
+	${MESON} test ${NINJA_OPT}
 
 dist:
 	DESTDIR="\$(DESTDIR)" ${NINJA} ${NINJA_OPT} dist


### PR DESCRIPTION
The 'mesontest' utility seems to be deprecated, or something? In any
case it's broken in 0.44: https://github.com/mesonbuild/meson/issues/2761

https://phabricator.endlessm.com/T21026